### PR TITLE
Remove unneeded action from CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,12 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: npm ci
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
     - name: sls deploy
       uses: serverless/github-action@master
       with:


### PR DESCRIPTION
Removed the configure aws credentials action from the cd pipeline. I was able to get access working locally through the IAM portal for deployments.