### PR TITLE
Removing dependency on serverless gh action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -22,18 +26,18 @@ jobs:
     
     - name: Install API Dependencies
       run: npm i
+
+    - name: Install Serverless Globally
+      run: npm i -g serverless
+
+    - name: Serverless AWS authentication
+      run: sls config credentials --provider aws --key ${{ secrets.AWS_ACCESS_KEY_ID }} --secret ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     
     - name: Install Serverless dependencies
-      uses: serverless/github-action@master
-      with:
-        args: dynamodb install --conceal
+      run: sls dynamodb install --conceal
 
     - name: Package for prod
-      uses: serverless/github-action@master
-      with:
-        args: package --stage prod
+      run: sls package --stage prod
 
     - name: Deploy to prod
-      uses: serverless/github-action@master
-      with:
-        args: deploy --package .serverless --stage prod --force
+      run: sls deploy --package .serverless --stage prod --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -22,11 +26,15 @@ jobs:
     
     - name: Install API Dependencies
       run: npm i
-    
+
+    - name: Install Serverless Globally
+      run: npm i -g serverless
+
+    - name: Serverless AWS authentication
+      run: sls config credentials --provider aws --key ${{ secrets.AWS_ACCESS_KEY_ID }} --secret ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
     - name: Install Serverless dependencies
-      uses: serverless/github-action@master
-      with:
-        args: dynamodb install --conceal
+      run: sls dynamodb install --conceal
 
     - name: Check lint
       run: npm run lint

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -2,8 +2,7 @@ service: NouriMeals-API
 
 # Reference: https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/
 
-frameworkVersion: "2"
-enableLocalInstallationFallback: true
+frameworkVersion: ">=2.3.0"
 
 plugins:
   - serverless-dynamodb-local


### PR DESCRIPTION
Instead of using the the serverless gh action for deploying
we just install serverless globally and run sls from there
so that we will not have issues with versioning from the gh
action

Closes #61 (+7 squashed commits)